### PR TITLE
feat: Add isAnyBeneficiaryInvalid property to group validation response

### DIFF
--- a/apps/beneficiary/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary/src/beneficiary/beneficiary.service.ts
@@ -1167,9 +1167,42 @@ export class BeneficiaryService {
       },
     });
 
-    return {
+    if (!group) {
+      throw new RpcException('Group not found');
+    }
+
+    // If groupPurpose is not found and groupedBeneficiaries is empty, return group with isGroupValidForAA as false
+    if (!group.groupPurpose || !group.groupedBeneficiaries?.length) {
+      return {
+        ...group,
+        isGroupValidForAA: false,
+        isAnyBeneficiaryInvalid: false,
+      }
+    }
+
+    // If group is found, check if it is valid for AA
+    const finalData = {
       ...group,
       isGroupValidForAA: await this.isGroupValidForAA(group.uuid),
+    };
+
+    // Check if any beneficiary has invalid account or phone number
+    let isAnyBeneficiaryInvalid = false;
+
+    // Only check for errors if groupPurpose is not COMMUNICATION and group is not valid for AA
+    if (finalData.groupPurpose !== GroupPurpose.COMMUNICATION && !finalData.isGroupValidForAA) {
+      for (const bef of finalData.groupedBeneficiaries) {
+        const extras = bef.Beneficiary.extras as Record<string, any>;
+        if (extras?.error) {
+          isAnyBeneficiaryInvalid = true;
+          break;
+        }
+      }
+    }
+
+    return {
+      ...finalData,
+      isAnyBeneficiaryInvalid
     };
   }
 

--- a/libs/sdk/src/types/beneficiary.types.ts
+++ b/libs/sdk/src/types/beneficiary.types.ts
@@ -16,4 +16,5 @@ export type GroupWithBeneficiaries = Prisma.BeneficiaryGroupGetPayload<{
 
 export interface GroupWithValidationAA extends GroupWithBeneficiaries {
     isGroupValidForAA: boolean;
+    isAnyBeneficiaryInvalid?: boolean;
 }


### PR DESCRIPTION
## Backend Changes:

1. Updated TypeScript Interface
   - Added isAnyBeneficiaryInvalid?: boolean to GroupWithValidationAA interface
2. Enhanced getOneGroup Method 
   - Added logic to check for beneficiary validation errors in the extras.error field
   - Returns isAnyBeneficiaryInvalid: true when any beneficiary has validation errors
   - Returns isAnyBeneficiaryInvalid: false for groups with no errors or COMMUNICATION purpose groups
