### PR TITLE
Integrate xcapit

### DIFF
--- a/libs/extensions/src/dtos/beneficiary/create-beneficiary.dto.ts
+++ b/libs/extensions/src/dtos/beneficiary/create-beneficiary.dto.ts
@@ -1,4 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { WalletService } from '@prisma/client';
 import { Beneficiary, Enums, TPIIData } from '@rahataid/sdk';
 import {
   ArrayNotEmpty,
@@ -161,4 +162,13 @@ export class CreateBeneficiaryDto implements Beneficiary {
   @ArrayNotEmpty()
 
   projectUUIDs?: string[];
+
+  @ApiPropertyOptional({
+    example: 'XCAPIT',
+    description: 'Beneficiary wallet service'
+  })
+  @IsOptional()
+  @IsEnum(WalletService)
+
+  walletService?: WalletService
 }

--- a/prisma/migrations/20250813052618_benef_wallet_service/migration.sql
+++ b/prisma/migrations/20250813052618_benef_wallet_service/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "WalletService" AS ENUM ('INTERNAL', 'XCAPIT');
+
+-- AlterTable
+ALTER TABLE "tbl_beneficiaries" ADD COLUMN     "walletService" "WalletService" NOT NULL DEFAULT 'INTERNAL';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -242,6 +242,7 @@ model Beneficiary {
   updatedAt      DateTime?      @updatedAt()
   deletedAt      DateTime?
   isVerified     Boolean        @default(false)
+  walletService  WalletService  @default(INTERNAL)
 
   pii                  BeneficiaryPii?        @relation("BeneficiaryToPii")
   BeneficiaryProject   BeneficiaryProject[]
@@ -374,6 +375,11 @@ enum PhoneStatus {
   NO_PHONE
   FEATURE_PHONE
   SMART_PHONE
+}
+
+enum WalletService{
+  INTERNAL
+  XCAPIT
 }
 
 // ++++++++++++++++++ END: Rahat - Projects +++++++++++++++++++++++

--- a/prisma/seed.xcapit-settings.ts
+++ b/prisma/seed.xcapit-settings.ts
@@ -1,0 +1,32 @@
+import { PrismaClient } from '@prisma/client';
+import { PrismaService } from '@rumsan/prisma';
+
+const prisma = new PrismaService();
+const prismaClient = new PrismaClient();
+
+const main = async () => {
+    try {
+        await prismaClient.setting.create({
+            data: {
+                name: "XCAPIT",
+                dataType: "OBJECT",
+                "value": {
+                    "URL": "https://qa.ltw.xcapit.com",
+                    "TOKEN": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InJhaGF0QHhjYXBpdC5jb20iLCJpYXQiOjE3NTQ5OTc1MjksImV4cCI6MTc1NTA4MzkyOX0.ef3QOBggtDdm0bKERNu8cR7wjIx5TYIwBAIc1JVL-VA"
+                },
+                requiredFields: ["URL", "TOKEN"]
+            }
+        })
+        console.log('xcapit settings created successfully');
+    } catch (error) {
+        console.error('Error creating setting:', error);
+    } finally {
+        await prisma.$disconnect();
+    }
+}
+
+main()
+    .catch((e) => {
+        console.error(e);
+        process.exit(1);
+    });


### PR DESCRIPTION
- walletService field as enum in beneficiary model to specify if it required INTERNAL or XCAPIT service.
- USE_EXTERNAL_WALLET & EXTERNAL_WALLET_SERVICE in env to specify if the beneficiary assigning to project requires external wallet creation e.g. XCAPIT.
- XCAPIT wallet creation while assigning beneficiary to project e.g. aidlink