### PR TITLE
fix: add idempotency key to vendor update and remove RPC calls

### DIFF
--- a/apps/rahat/src/utils/idempotency-key.ts
+++ b/apps/rahat/src/utils/idempotency-key.ts
@@ -5,13 +5,46 @@ import { createHash } from 'crypto';
  * produce the same SHA-256 hex digest. Used by CRM IdempotencyInterceptor.
  */
 export function generateIdempotencyKey(cmd: unknown, payload: unknown): string {
-  const normalizedCmd =
-    typeof cmd === 'string' ? cmd : JSON.stringify(cmd ?? {});
-
-  const sortedKeys = Object.keys(payload ?? {}).sort();
-  const normalizedPayload = JSON.stringify(payload ?? {}, sortedKeys);
+  const normalizedCmd = stringifyCanonical(cmd, 'unknown_cmd');
+  const normalizedPayload = stringifyCanonical(payload, 'unknown_payload');
 
   return createHash('sha256')
     .update(`${normalizedCmd}::${normalizedPayload}`)
     .digest('hex');
+}
+
+function stringifyCanonical(value: unknown, fallback: string): string {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : fallback;
+  }
+
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+
+  try {
+    return JSON.stringify(sortObjectDeep(value));
+  } catch {
+    return String(value);
+  }
+}
+
+function sortObjectDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortObjectDeep(item));
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.keys(value)
+    .sort()
+    .reduce((acc, key) => {
+      (acc as Record<string, unknown>)[key] = sortObjectDeep(
+        (value as Record<string, unknown>)[key]
+      );
+      return acc;
+    }, {} as Record<string, unknown>);
 }

--- a/apps/rahat/src/vendors/vendors.service.ts
+++ b/apps/rahat/src/vendors/vendors.service.ts
@@ -30,6 +30,7 @@ import { NotificationService } from '../notification/notification.service';
 import { UsersService } from '../users/users.service';
 import { isAddress } from '../utils/web3';
 import { WalletService } from '../wallet/wallet.service';
+import { generateIdempotencyKey } from '../utils/idempotency-key';
 import { handleMicroserviceCall } from './handleMicroServiceCall.util';
 
 const paginate: PaginatorTypes.PaginateFunction = paginator({ perPage: 20 });
@@ -445,7 +446,11 @@ export class VendorsService {
       },
     });
 
-    return this.client.send({ cmd: VendorJobs.UPDATE }, result);
+    const cmd = { cmd: VendorJobs.UPDATE };
+    return this.client.send(cmd, {
+      ...result,
+      idempotencyKey: generateIdempotencyKey(cmd, result),
+    });
   }
 
   async removeVendor(uuid: UUID, projectId?: UUID) {
@@ -477,7 +482,11 @@ export class VendorsService {
       },
     });
 
-    return this.client.send({ cmd: VendorJobs.REMOVE }, uuid);
+    const cmd = { cmd: VendorJobs.REMOVE };
+    return this.client.send(cmd, {
+      uuid,
+      idempotencyKey: generateIdempotencyKey(cmd, { uuid }),
+    });
   }
 
   async getVendorClaimStats(dto) {


### PR DESCRIPTION
Linked PR - https://github.com/rahataid/rahat-project-crm/pull/26
**Problem**
The CRM [IdempotencyInterceptor](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) throws [RpcException('Missing idempotency key')](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on any [@Idempotent()](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)-decorated handler that receives a payload without an [idempotencyKey](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Two direct [client.send()](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) calls in [VendorsService](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — [updateVendor()](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [removeVendor()](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — were missing this key, causing runtime failures when those RPC handlers were hit.

Additionally, the existing [generateIdempotencyKey()](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) utility used [JSON.stringify(payload, sortedKeys)](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) intending to sort keys for deterministic hashing, but [JSON.stringify](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)'s second argument is a replacer (filters keys), not a sorter — meaning key order was never actually normalized.

**Changes**
- [vendors.service.ts](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Added [idempotencyKey](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [updateVendor()](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [removeVendor()](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) RPC payloads using [generateIdempotencyKey()](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- [idempotency-key.ts](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Replaced broken key-sort approach with proper recursive [sortObjectDeep()](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for deterministic serialization. Added [stringifyCanonical()](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with null/undefined fallback handling.

**Testing**
- Vendor update/remove calls no longer throw [Missing idempotency key](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- [generateIdempotencyKey(cmd, payload)](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) produces identical hashes regardless of property insertion order.