### PR TITLE
  refactor(wallet): improve transaction type definitions for EVM and Stellar

### DIFF
--- a/libs/wallet/src/evm/connectedWallet.spec.ts
+++ b/libs/wallet/src/evm/connectedWallet.spec.ts
@@ -1,0 +1,71 @@
+import { Wallet, type TransactionResponse } from 'ethers';
+import { ConnectedWallet } from './connectedWallet';
+import type {
+  EVM_BroadcastedTransaction,
+  EVM_UnsignedTransaction,
+} from './types';
+
+describe('EVM ConnectedWallet', () => {
+  const signer = Wallet.createRandom();
+  const walletKeys = {
+    address: signer.address,
+    privateKey: signer.privateKey,
+    publicKey: signer.publicKey,
+    blockchain: 'EVM',
+  };
+
+  const transactionRequest: EVM_UnsignedTransaction = {
+    to: Wallet.createRandom().address,
+    nonce: 0,
+    type: 2,
+    chainId: 11155111,
+    gasLimit: BigInt(21_000),
+    maxFeePerGas: BigInt(1),
+    maxPriorityFeePerGas: BigInt(1),
+    value: BigInt(1),
+  };
+
+  it('signTransaction serializes an EVM transaction request', async () => {
+    const connectedWallet = new ConnectedWallet(
+      walletKeys,
+      'http://localhost:8545'
+    );
+
+    const signedTransaction = await connectedWallet.signTransaction(
+      transactionRequest
+    );
+
+    expect(typeof signedTransaction).toBe('string');
+    expect(signedTransaction.startsWith('0x')).toBe(true);
+  });
+
+  it('sendTransaction signs then broadcasts the serialized transaction', async () => {
+    const connectedWallet = new ConnectedWallet(
+      walletKeys,
+      'http://localhost:8545'
+    );
+
+    const signedTransaction = '0xsigned-transaction';
+    const transactionResponse = {
+      hash: '0x123',
+    } as EVM_BroadcastedTransaction;
+
+    jest
+      .spyOn(connectedWallet, 'signTransaction')
+      .mockResolvedValue(signedTransaction);
+
+    if (!connectedWallet.provider) {
+      throw new Error('Expected JsonRpcProvider to be initialized');
+    }
+
+    const broadcastSpy = jest
+      .spyOn(connectedWallet.provider, 'broadcastTransaction')
+      .mockResolvedValue(transactionResponse as TransactionResponse);
+
+    await expect(
+      connectedWallet.sendTransaction(transactionRequest)
+    ).resolves.toBe(transactionResponse);
+
+    expect(broadcastSpy).toHaveBeenCalledWith(signedTransaction);
+  });
+});

--- a/libs/wallet/src/evm/connectedWallet.ts
+++ b/libs/wallet/src/evm/connectedWallet.ts
@@ -1,15 +1,24 @@
-import { JsonRpcProvider, Provider, Wallet } from "ethers";
+import { JsonRpcProvider, Wallet } from "ethers";
 import { IConnectedWallet, WalletKeys } from "../types";
-import { EVM_CreateTransactionWithPk } from "./types";
+import {
+    EVM_BroadcastedTransaction,
+    EVM_CreateTransactionWithPk,
+    EVM_SignedTransaction,
+    EVM_UnsignedTransaction,
+} from "./types";
 import { getEVMTransaction } from "./utils";
 
 
-export class ConnectedWallet implements IConnectedWallet {
+export class ConnectedWallet implements IConnectedWallet<
+    EVM_UnsignedTransaction,
+    EVM_SignedTransaction,
+    EVM_BroadcastedTransaction
+> {
 
     blockchainType = "EVM";
     rpcUrl: string;
     currentWalletKeys: WalletKeys
-    provider?: Provider;
+    provider?: JsonRpcProvider;
     chainId?: bigint;
 
     constructor(walletKeys: WalletKeys, rpcUrl: string) {
@@ -26,8 +35,9 @@ export class ConnectedWallet implements IConnectedWallet {
         return wallet.signMessage(message);
     }
 
-    //TODO define transaction type
-    async signTransaction(transactionData: any): Promise<any> {
+    async signTransaction(
+        transactionData: EVM_UnsignedTransaction
+    ): Promise<EVM_SignedTransaction> {
         if (!this.currentWalletKeys || !this.provider) {
             throw new Error("No current account or provider set for signing transaction");
         }
@@ -35,15 +45,14 @@ export class ConnectedWallet implements IConnectedWallet {
         return wallet.signTransaction(transactionData);
     }
 
-    async sendTransaction(rawTransaction: any): Promise<any> {
+    async sendTransaction(
+        rawTransaction: EVM_UnsignedTransaction
+    ): Promise<EVM_BroadcastedTransaction> {
         if (!this.provider) {
             throw new Error("Provider is not initialized");
         }
         const signedTransaction = await this.signTransaction(rawTransaction);
-        if (!this.provider.sendTransaction) {
-            throw new Error("Provider's sendTransaction method is not available");
-        }
-        return await this.provider.sendTransaction(signedTransaction);
+        return this.provider.broadcastTransaction(signedTransaction);
     }
 
     getWalletKeys(): WalletKeys {
@@ -51,7 +60,9 @@ export class ConnectedWallet implements IConnectedWallet {
     }
 
     //TODO : cleanup this 
-    async writeContract(transactionParams: EVM_CreateTransactionWithPk) {
+    async writeContract(
+        transactionParams: EVM_CreateTransactionWithPk
+    ): Promise<EVM_BroadcastedTransaction> {
         if (!this.provider) {
             throw new Error("Provider is not initialized");
         }
@@ -60,9 +71,7 @@ export class ConnectedWallet implements IConnectedWallet {
             networkProvider: this.rpcUrl,
         });
 
-        const signedTxn = await this.signTransaction(txn)
-
-        this.sendTransaction(signedTxn);
+        return this.sendTransaction(txn);
     }
 
 }

--- a/libs/wallet/src/evm/types.ts
+++ b/libs/wallet/src/evm/types.ts
@@ -1,14 +1,31 @@
 import {
     AddressLike,
-    ContractTransaction,
+    BigNumberish,
     ethers,
     Interface,
     InterfaceAbi,
+    TransactionRequest,
+    TransactionResponse,
 } from "ethers";
 
 export type ABI = Interface | InterfaceAbi;
 
 export type ARGS = string | number | bigint | boolean | ethers.BytesLike;
+
+/**
+ * Normalized EVM transaction request used before signing or broadcasting.
+ */
+export type EVM_UnsignedTransaction = TransactionRequest;
+
+/**
+ * Serialized raw transaction returned by ethers wallets after signing.
+ */
+export type EVM_SignedTransaction = string;
+
+/**
+ * Transaction response returned after a signed payload is broadcast.
+ */
+export type EVM_BroadcastedTransaction = TransactionResponse;
 
 export type EVM_Transaction = {
     abi: ABI;
@@ -29,7 +46,7 @@ export type EVM_TransactionWithURL = EVM_Transaction & {
 };
 
 export type EVM_TransactionToSign = {
-    txn: ContractTransaction;
+    txn: EVM_UnsignedTransaction;
     privateKey: `0x${string}`;
 };
 
@@ -38,7 +55,7 @@ export type EVM_TransactionToSignWithURL = EVM_TransactionToSign & {
 };
 
 export type EVM_TransactionToSend = {
-    signedTxn: string;
+    signedTxn: EVM_SignedTransaction;
 };
 
 export type EVM_TransactionToSendWithURL = EVM_TransactionToSend & {
@@ -46,9 +63,9 @@ export type EVM_TransactionToSendWithURL = EVM_TransactionToSend & {
 };
 
 export type EVM_TransactionOptions = {
-    gasPrice?: number;
-    gasLimit?: number;
-    value?: number;
-    maxFeePerGas?: number;
-    maxPriorityFeePerGas?: number;
+    gasPrice?: BigNumberish;
+    gasLimit?: BigNumberish;
+    value?: BigNumberish;
+    maxFeePerGas?: BigNumberish;
+    maxPriorityFeePerGas?: BigNumberish;
 };

--- a/libs/wallet/src/evm/utils.ts
+++ b/libs/wallet/src/evm/utils.ts
@@ -1,9 +1,9 @@
 import { ethers } from "ethers";
-import { EVM_TransactionWithURL } from "./types";
+import { EVM_TransactionWithURL, EVM_UnsignedTransaction } from "./types";
 
 export async function getEVMTransaction(
     transactionParams: EVM_TransactionWithURL
-): Promise<any> {
+): Promise<EVM_UnsignedTransaction> {
     const provider = new ethers.JsonRpcProvider(
         transactionParams.networkProvider
     );

--- a/libs/wallet/src/stellar/connectedWallet.spec.ts
+++ b/libs/wallet/src/stellar/connectedWallet.spec.ts
@@ -1,0 +1,49 @@
+import { Account, Keypair, Networks } from 'stellar-sdk';
+import { ConnectedWallet } from './connectedWallet';
+import type { StellarTransactionRequest } from './types';
+
+describe('Stellar ConnectedWallet', () => {
+  const signer = Keypair.random();
+  const walletKeys = {
+    address: signer.publicKey(),
+    privateKey: signer.secret(),
+    publicKey: signer.publicKey(),
+    blockchain: 'STELLAR',
+  };
+
+  const createTransactionRequest = (): StellarTransactionRequest => ({
+    sourceAccount: new Account(signer.publicKey(), '1'),
+    networkPassphrase: Networks.TESTNET,
+    timeoutSeconds: 60,
+  });
+
+  it('signTransaction returns a signed Stellar transaction envelope', async () => {
+    const connectedWallet = new ConnectedWallet(
+      walletKeys,
+      'http://localhost:8000'
+    );
+
+    const signedTransaction = await connectedWallet.signTransaction(
+      createTransactionRequest()
+    );
+
+    expect(signedTransaction.signatures).toHaveLength(1);
+    expect(signedTransaction.networkPassphrase).toBe(Networks.TESTNET);
+  });
+
+  it('sendTransaction returns the signed transaction envelope', async () => {
+    const connectedWallet = new ConnectedWallet(
+      walletKeys,
+      'http://localhost:8000'
+    );
+    const transactionRequest = createTransactionRequest();
+
+    const signSpy = jest.spyOn(connectedWallet, 'signTransaction');
+    const signedTransaction = await connectedWallet.sendTransaction(
+      transactionRequest
+    );
+
+    expect(signSpy).toHaveBeenCalledWith(transactionRequest);
+    expect(signedTransaction.signatures).toHaveLength(1);
+  });
+});

--- a/libs/wallet/src/stellar/connectedWallet.ts
+++ b/libs/wallet/src/stellar/connectedWallet.ts
@@ -1,8 +1,14 @@
-import { BASE_FEE, Keypair, Networks, TransactionBuilder } from 'stellar-sdk';
+import { BASE_FEE, Keypair, TransactionBuilder } from 'stellar-sdk';
 import { IConnectedWallet, WalletKeys } from "../types.js";
+import {
+    DEFAULT_STELLAR_NETWORK_PASSPHRASE,
+    DEFAULT_STELLAR_TRANSACTION_TIMEOUT,
+    StellarSignedTransaction,
+    StellarTransactionRequest,
+} from './types.js';
 
 
-export class ConnectedWallet implements IConnectedWallet {
+export class ConnectedWallet implements IConnectedWallet<StellarTransactionRequest, StellarSignedTransaction> {
     blockchainType = "STELLAR";
     rpcUrl: string;
     currentWalletKeys?: WalletKeys
@@ -22,38 +28,32 @@ export class ConnectedWallet implements IConnectedWallet {
     }
 
 
-    //TODO: Desine transaction type
-    async signTransaction(transactionData: any): Promise<any> {
+    async signTransaction(transactionRequest: StellarTransactionRequest): Promise<StellarSignedTransaction> {
 
         if (!this.currentWalletKeys) {
             throw new Error("No current account set for signing");
         }
         const keypair = Keypair.fromSecret(this.currentWalletKeys.privateKey);
-        const transaction = new TransactionBuilder(transactionData, {
-            fee: BASE_FEE,
-            networkPassphrase: Networks.PUBLIC // or Networks.TESTNET for testnet
+        const transaction = new TransactionBuilder(transactionRequest.sourceAccount, {
+            fee: transactionRequest.fee ?? BASE_FEE,
+            networkPassphrase:
+                transactionRequest.networkPassphrase ??
+                DEFAULT_STELLAR_NETWORK_PASSPHRASE,
         })
-            .setTimeout(30)
+            .setTimeout(
+                transactionRequest.timeoutSeconds ??
+                DEFAULT_STELLAR_TRANSACTION_TIMEOUT
+            )
             .build();
 
-        return transaction.sign(keypair);
+        transaction.sign(keypair);
+        return transaction;
     }
 
-    //TDOD: implement Send transactions
-    async sendTransaction(transactionData: any): Promise<any> {
-
-        if (!this.currentWalletKeys) {
-            throw new Error("No current account set for signing");
-        }
-        const keypair = Keypair.fromSecret(this.currentWalletKeys.privateKey);
-        const transaction = new TransactionBuilder(transactionData, {
-            fee: BASE_FEE,
-            networkPassphrase: Networks.PUBLIC // or Networks.TESTNET for testnet
-        })
-            .setTimeout(30)
-            .build();
-
-        return transaction.sign(keypair);
+    async sendTransaction(
+        transactionRequest: StellarTransactionRequest
+    ): Promise<StellarSignedTransaction> {
+        return this.signTransaction(transactionRequest);
     }
 
     getWalletKeys(): WalletKeys {

--- a/libs/wallet/src/stellar/types.ts
+++ b/libs/wallet/src/stellar/types.ts
@@ -1,0 +1,29 @@
+import { Networks, Transaction } from 'stellar-sdk';
+
+/**
+ * Minimal Stellar source-account shape accepted by TransactionBuilder.
+ * This keeps the wallet compatible with both `Account` and Horizon account responses.
+ */
+export interface StellarTransactionSourceAccount {
+  accountId(): string;
+  sequenceNumber(): string;
+  incrementSequenceNumber(): void;
+}
+
+/**
+ * Structured input for building and signing a Stellar transaction envelope.
+ */
+export interface StellarTransactionRequest {
+  sourceAccount: StellarTransactionSourceAccount;
+  fee?: string;
+  networkPassphrase?: string;
+  timeoutSeconds?: number;
+}
+
+/**
+ * Stellar currently returns the signed envelope so callers can submit it upstream.
+ */
+export type StellarSignedTransaction = Transaction;
+
+export const DEFAULT_STELLAR_NETWORK_PASSPHRASE = Networks.PUBLIC;
+export const DEFAULT_STELLAR_TRANSACTION_TIMEOUT = 30;

--- a/libs/wallet/src/types.ts
+++ b/libs/wallet/src/types.ts
@@ -25,20 +25,31 @@ export interface WalletKeys {
   mnemonic?: string; // Optional - Only if you want to support exports to external wallets and recovery
 }
 
-export interface IConnectedWallet {
+/**
+ * Standard transaction contract shared by connected wallet implementations.
+ * Each chain can specialize the request, signed payload, and send result types.
+ */
+export interface IConnectedWallet<
+  TUnsignedTransaction = unknown,
+  TSignedTransaction = unknown,
+  TSendResult = TSignedTransaction,
+> {
   signMessage(message: string): Promise<string>;
-  sendTransaction(rawTransaction: any): Promise<any>;
+  signTransaction(transaction: TUnsignedTransaction): Promise<TSignedTransaction>;
+  sendTransaction(transaction: TUnsignedTransaction): Promise<TSendResult>;
   getWalletKeys(): WalletKeys;
 }
 
-export interface IWalletManager {
+export interface IWalletManager<
+  TConnectedWallet extends IConnectedWallet = IConnectedWallet,
+> {
   init(): Promise<void>;
-  createWallet(): Promise<IConnectedWallet>;
-  importWallet(privateKey: string): Promise<IConnectedWallet>;
+  createWallet(): Promise<TConnectedWallet>;
+  importWallet(privateKey: string): Promise<TConnectedWallet>;
   connect(
     walletAddress: string,
     blockchain: ChainType
-  ): Promise<IConnectedWallet>;
+  ): Promise<TConnectedWallet>;
 }
 
 export type ChainType = 'stellar' | 'evm';


### PR DESCRIPTION
Closes Improve TypeScript Type Definitions for Transaction Objects #444

  ## Summary

  This PR improves transaction type safety in the wallet module by replacing loose transaction handling with explicit EVM and Stellar transaction types.

  The main goal is to make transaction shapes predictable, remove `any` usage in the connected wallet implementations, and improve autocomplete/type checking for transaction-related code.

  ## Changes

  - Added shared generic transaction contracts to `IConnectedWallet`
  - Introduced explicit EVM transaction aliases:
    - unsigned transaction request
    - signed transaction payload
    - broadcast transaction response
  - Introduced explicit Stellar transaction request and signed transaction types
  - Updated the following files to use those types explicitly:
    - `libs/wallet/src/evm/connectedWallet.ts`
    - `libs/wallet/src/stellar/connectedWallet.ts`
  - Updated EVM helper typing so transaction creation returns a typed transaction request
  - Added brief type comments for the new transaction contracts
  - Added focused wallet tests covering signing/sending behavior for both EVM and Stellar

  ## Notes

  - This PR is focused on transaction typing and connected wallet behavior.
  - No live network integration tests were added in this PR.
  - The EVM path now uses the proper broadcast flow for signed transactions.
  - The Stellar connected wallet still returns a signed transaction envelope; it does not submit to Horizon/Soroban in this change.

  ## Testing

  Passed:

  - `tsc -p libs/wallet/tsconfig.lib.json --noEmit`
  - `tsc -p libs/wallet/tsconfig.spec.json --noEmit`
  - `tsc -p apps/rahat/tsconfig.app.json --noEmit`
  - `jest --config libs/wallet/jest.config.ts --runInBand`