### PR TITLE
concatenate firstname and lastname into pii.name during import

### DIFF
--- a/apps/rahat/src/imports/csv-parser.util.ts
+++ b/apps/rahat/src/imports/csv-parser.util.ts
@@ -1,5 +1,5 @@
-import { parse } from 'csv-parse/sync';
 import { generateRandomWallet } from '@rahataid/sdk/utils';
+import { parse } from 'csv-parse/sync';
 import { STANDARD_FIELD_MAP, VALID_GENDERS } from './imports.constants';
 
 export interface MappedRow {
@@ -45,6 +45,14 @@ function mapCSVRow(row: Record<string, string>, rowIndex: number): MappedRow {
         extras[csvColumn] = value;
       }
     }
+  }
+
+  // Handle name joining from firstName and lastName
+  const fName = extras['firstName'] || extras['firstname'] || extras['FirstName'];
+  const lName = extras['lastName'] || extras['lastname'] || extras['LastName'];
+
+  if (fName || lName) {
+    pii.name = `${fName || ''} ${lName || ''}`.trim();
   }
 
   // Generate wallet address if not provided


### PR DESCRIPTION
## Problem
Currently, `firstName` and `lastName` columns in the import CSV are not defined in the `STANDARD_FIELD_MAP`. As a result:
1. They fall into the `extras` category automatically.
2. The `pii.name` field remains empty in the database.
3. Because `pii.name` is empty, the UI does not display the beneficiary's name in the list views.

## Solution
This PR adds a specific handler in the `mapCSVRow` utility to address this:
- **Concatenation**: It checks the `extras` object for `firstName` and `lastName` (handling various casing like `firstname` or `FirstName`).
- **PII Mapping**: It joins these values and assigns them to `pii.name` so the system can correctly identify and display the beneficiary.
- **Redundancy**: The individual fields are kept in `extras` to ensure no source data is lost, while ensuring the core `name` field is populated for the UI.

## Changes
- Modified `apps/rahat/src/imports/csv-parser.util.ts` to join name components after the initial mapping loop.

## Impact
- Beneficiary names will now correctly appear in the UI after import.
- No changes required to the `STANDARD_FIELD_MAP` constant, maintaining its current structure.
