### PR TITLE
fix(upload): decode Nepali filenames correctly

### DIFF
--- a/apps/rahat/src/upload/upload.controller.ts
+++ b/apps/rahat/src/upload/upload.controller.ts
@@ -24,7 +24,7 @@ export class UploadController {
   async uploadFile(@UploadedFile() file: any) {
     const buffer = file.buffer;
     const mimeType = file.mimetype;
-    const fileName = file.originalname.replace(/\s/g, "-");
+    const fileName = Buffer.from(file.originalname, "latin1").toString("utf8").replace(/\s/g, "-");
 
     const folderName = "dev"
     const rootFolderName = "aa"


### PR DESCRIPTION
## 🔗 Related Issue

https://github.com/rahataid/rahat-ui/issues/2092

* [x] Added issue link

## 📌 Description

This PR fixes an encoding issue where uploaded files with Nepali filenames were stored and returned with garbled characters instead of their original Devanagari names.

Previously, when uploading a file with a Nepali filename (e.g., `परीक्षण.mp4`), the backend interpreted the filename using an incorrect encoding, resulting in mojibake such as `à¤ªà¤°à¥à¤à¥à¤·à¤£.mp4` being stored and returned in the API response. This caused Nepali filenames to be displayed incorrectly in the Communication section.

Changes made:

* Decoded uploaded filenames from the received encoding to UTF-8 before processing.
* Preserved Nepali (Devanagari) filenames during upload.
* Ensured filenames are sanitized after decoding by replacing spaces with hyphens.

## ✅ Checklist

* [x] No console.log or debug code left
* [ ] Proper error handling implemented
* [ ] Loading states handled (if needed)
* [ ] API calls handled safely
* [x] No unnecessary code or comments
* [x] Self-reviewed code for logic, edge cases, and potential issues

## 🎯 Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] UI update
* [ ] Refactor
* [ ] Performance improvement

## 📸 Before / After

**Before**

<img width="1359" height="656" alt="image" src="https://github.com/user-attachments/assets/c4bb0a76-b51e-4043-aca2-dbb2cb0570b7" />

**After**

<img width="1710" height="1069" alt="image" src="https://github.com/user-attachments/assets/6269e2c0-5ec5-41eb-835d-42bf985bb98f" />

## 🧪 How to Test

1. Navigate to **Activity → Communication**.
2. Upload a media file with a Nepali filename (e.g., `परीक्षण.mp4`).
3. Verify that the upload succeeds.
4. Verify that the filename returned by the API is displayed correctly in Nepali instead of garbled characters.
5. Upload a file with an English filename and verify that it continues to work as expected.

## ⚠️ Notes for Reviewer

This change only affects filename encoding during file upload. English (ASCII) filenames remain unchanged, while Unicode filenames (including Nepali) are now preserved correctly.
