### PR TITLE
syncForecastData action registered

### DIFF
--- a/apps/rahat/src/projects/actions/ms.trigger.action.ts
+++ b/apps/rahat/src/projects/actions/ms.trigger.action.ts
@@ -45,6 +45,8 @@ export const MS_TRIGGERS_JOBS = {
     // GET_GLOFAS: 'ms.jobs.waterLevels.getGlofas',
     GET_GFH: 'ms.jobs.waterLevels.getGfh',
   },
+  SYNC_FORECAST_DATA: 'ms.jobs.sources-data.syncForecastData',
+
   RAINFALL_LEVELS: {
     GET_DHM: 'ms.jobs.rainfallLevels.getDhm',
     GET_GLOFAS: 'ms.jobs.rainfallLevels.getGlofas',
@@ -376,6 +378,15 @@ export const msTriggerActions: ProjectActionFunc = {
     );
   },
 
+  [MS_ACTIONS.MS_SYNC_FORECAST_DATA]: (uuid, payload, sendCommand) => {
+    payload.appId = uuid || payload.appId;
+
+    return sendCommand(
+      { cmd: MS_TRIGGERS_JOBS.SYNC_FORECAST_DATA },
+      payload
+    );
+  },
+
   [MS_ACTIONS.MS_RAINFALL_LEVELS.GET_GLOFAS]: (uuid, payload, sendCommand) => {
     payload.appId = uuid || payload.appId;
 
@@ -469,7 +480,7 @@ export const msTriggerActions: ProjectActionFunc = {
 
   [MS_ACTIONS.MS_ACTIVITIES.BULK_ADD]: (uuid, payload, sendCommand) => {
     payload.appId = uuid || payload.appId;
-    
+
     return sendCommand({ cmd: MS_TRIGGERS_JOBS.ACTIVITIES.BULK_ADD }, payload);
   },
 

--- a/libs/sdk/src/aa/aa.events.ts
+++ b/libs/sdk/src/aa/aa.events.ts
@@ -6,6 +6,8 @@ export const JOBS = {
     GET_DHM: 'aa.jobs.waterLevels.getDhm',
     GET_GLOFAS: 'aa.jobs.waterLevels.getGlofas',
   },
+
+  SYNC_FORECAST_DATA: 'ms.jobs.sources-data.syncForecastData',
   TRIGGERS: {
     DEV_ONLY: 'aa.jobs.triggers.devOnly',
     GET_ALL: 'aa.jobs.triggers.getAll',

--- a/libs/sdk/src/aa/aa.events.ts
+++ b/libs/sdk/src/aa/aa.events.ts
@@ -7,7 +7,8 @@ export const JOBS = {
     GET_GLOFAS: 'aa.jobs.waterLevels.getGlofas',
   },
 
-  SYNC_FORECAST_DATA: 'ms.jobs.sources-data.syncForecastData',
+  // SYNC_FORECAST_DATA: 'ms.jobs.sources-data.syncForecastData',
+
   TRIGGERS: {
     DEV_ONLY: 'aa.jobs.triggers.devOnly',
     GET_ALL: 'aa.jobs.triggers.getAll',

--- a/libs/sdk/src/constants/index.ts
+++ b/libs/sdk/src/constants/index.ts
@@ -583,6 +583,9 @@ export const MS_ACTIONS = {
     GET_DHM: 'ms.rainfallLevels.getDhm',
     GET_GLOFAS: 'ms.rainfallLevels.getGlofas',
   },
+
+  MS_SYNC_FORECAST_DATA: 'ms.jobs.sources-data.syncForecastData',
+
   MS_HUMIDITY: {
     GET_DHM: 'ms.humidity.getDhm',
     GET_DHM_SINGLE_SERIES: 'ms.humidity.getDhmSingleSeries',
@@ -595,6 +598,7 @@ export const MS_ACTIONS = {
     GET_ALL_GLOFAS: 'ms.probFlood.getAllGlofas',
     GET_ONE_GLOFAS: 'ms.probFlood.getOneGlofas',
   },
+
   MS_ACTIVITIES: {
     GET_ONE: 'ms.activities.getOne',
     GET_ALL: 'ms.activities.getAll',

--- a/libs/sdk/src/constants/index.ts
+++ b/libs/sdk/src/constants/index.ts
@@ -584,7 +584,7 @@ export const MS_ACTIONS = {
     GET_GLOFAS: 'ms.rainfallLevels.getGlofas',
   },
 
-  MS_SYNC_FORECAST_DATA: 'ms.jobs.sources-data.syncForecastData',
+  MS_SYNC_FORECAST_DATA: 'ms.sources-data.syncForecastData',
 
   MS_HUMIDITY: {
     GET_DHM: 'ms.humidity.getDhm',


### PR DESCRIPTION
- To support manual forecast data synchronization, it adds a new action to the command dispatch layer that forwards the synchronization request to the Forecast Service.