### PR TITLE
feat: applying and validating phone number in village doctor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,8 @@ USE_STATIC_OTP=true
 STATIC_OTP=1234
 
 WALLET_PATH=wallet_storage
+
+# Kobo import: when true, phones without a country code get the calling code
+# from the COUNTRY_CODE_SETTINGS setting. Enable in production only.
+AUTO_APPLY_KOBO_COUNTRY_CODE=false
+COUNTRY_CODE_CACHE_TTL_MS=60000

--- a/apps/rahat/src/projects/project.service.spec.ts
+++ b/apps/rahat/src/projects/project.service.spec.ts
@@ -1,213 +1,525 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getQueueToken } from '@nestjs/bull';
 import { PrismaService } from '@rumsan/prisma';
 import { ProjectService } from './project.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { ProjectEvents } from '@rahataid/sdk';
+import { BQUEUE, ProjectEvents } from '@rahataid/sdk';
 import { RequestContextService } from '../request-context/request-context.service';
 import { randomUUID } from 'crypto';
 import { ProjectStatus } from '@rahataid/sdk/enums';
+import * as envConfig from '../utils/envConfig';
 
 jest.mock('@nestjs/event-emitter', () => ({
-    EventEmitter2: jest.fn().mockImplementation(() => ({
-        emit: jest.fn(),
-    })),
+  EventEmitter2: jest.fn().mockImplementation(() => ({
+    emit: jest.fn(),
+  })),
 }));
 
 describe('ProjectService', () => {
-    let service: ProjectService;
-    let prisma: PrismaService;
-    let eventEmitter: EventEmitter2;
+  let service: ProjectService;
+  let prisma: PrismaService;
+  let eventEmitter: EventEmitter2;
 
-    beforeEach(async () => {
-      const module: TestingModule = await Test.createTestingModule({
-        providers: [
-            ProjectService,
-            {
-                provide: PrismaService,
-                useValue: {
-                    project: {
-                        create: jest.fn(),
-                        findMany: jest.fn(),
-                        findUnique: jest.fn(),
-                        update: jest.fn()
-                    }
-                }
-            },
-            {
-                provide: EventEmitter2,
-                useValue: new (EventEmitter2 as any)()
-            },
-            {
-                provide: RequestContextService,
-                useValue: {},
-            },
-            {
-                provide: 'RAHAT_CLIENT',
-                useValue: { 
-                    send: jest.fn(), 
-                    emit: jest.fn(),
-                },
-            },
-        ]
-      }).compile();
-
-      service = module.get<ProjectService>(ProjectService);
-      prisma = module.get<PrismaService>(PrismaService);
-      eventEmitter = module.get<EventEmitter2>(EventEmitter2);
-    });
-
-    const mockResponse = [
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProjectService,
         {
-            id: 1,
-            uuid: randomUUID(),
-            name: "Test Project 1",
-            description: "This is the description for Test Project 1.",
-            status: "NOT_READY",
-            type: "X",
-            contractAddress: "0x00",
-            extras: {
-                test: "test"
+          provide: PrismaService,
+          useValue: {
+            project: {
+              create: jest.fn(),
+              findMany: jest.fn(),
+              findUnique: jest.fn(),
+              update: jest.fn(),
             },
-            createdAt: "2024-09-02T11:59:25.229Z",
-            updatedAt: "2024-09-02T11:59:25.229Z",
-            deletedAt: null
+            setting: {
+              findUnique: jest.fn(),
+            },
+          },
         },
         {
-            id: 2,
-            uuid: randomUUID(),
-            name: "Test Project 2",
-            description: "This is the description for Test Project 2.",
-            status: "NOT_READY",
-            type: "X",
-            contractAddress: "0x00",
-            extras: {
-              test: "test"
-            },
-            createdAt: "2024-09-02T11:59:25.229Z",
-            updatedAt: "2024-09-02T11:59:25.229Z",
-            deletedAt: null
-        }
-    ];
+          provide: EventEmitter2,
+          useValue: new (EventEmitter2 as any)(),
+        },
+        {
+          provide: RequestContextService,
+          useValue: {},
+        },
+        {
+          provide: 'RAHAT_CLIENT',
+          useValue: {
+            send: jest.fn(),
+            emit: jest.fn(),
+          },
+        },
+        {
+          provide: getQueueToken(BQUEUE.META_TXN),
+          useValue: {
+            add: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
 
-    describe('create', () => {
-        it('should create new project with required details', async () => {
-            const mockRequest = {
-                name: "Test",
-                description: "This is description for testing.",
-                type: "X",
-                extras: {
-                    test: "test"
-                },
-                contractAddress: "0x00"
-            };
-            (prisma.project.create as jest.Mock).mockResolvedValue(mockRequest);
-            const result = await service.create(mockRequest);
-            expect(result).toBeDefined();
-            expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
-            expect(eventEmitter.emit).toHaveBeenCalledWith(
-                ProjectEvents.PROJECT_CREATED, expect.any(Object)
-            );
-        });
+    service = module.get<ProjectService>(ProjectService);
+    prisma = module.get<PrismaService>(PrismaService);
+    eventEmitter = module.get<EventEmitter2>(EventEmitter2);
+  });
+
+  const mockResponse = [
+    {
+      id: 1,
+      uuid: randomUUID(),
+      name: 'Test Project 1',
+      description: 'This is the description for Test Project 1.',
+      status: 'NOT_READY',
+      type: 'X',
+      contractAddress: '0x00',
+      extras: {
+        test: 'test',
+      },
+      createdAt: '2024-09-02T11:59:25.229Z',
+      updatedAt: '2024-09-02T11:59:25.229Z',
+      deletedAt: null,
+    },
+    {
+      id: 2,
+      uuid: randomUUID(),
+      name: 'Test Project 2',
+      description: 'This is the description for Test Project 2.',
+      status: 'NOT_READY',
+      type: 'X',
+      contractAddress: '0x00',
+      extras: {
+        test: 'test',
+      },
+      createdAt: '2024-09-02T11:59:25.229Z',
+      updatedAt: '2024-09-02T11:59:25.229Z',
+      deletedAt: null,
+    },
+  ];
+
+  describe('create', () => {
+    it('should create new project with required details', async () => {
+      const mockRequest = {
+        name: 'Test',
+        description: 'This is description for testing.',
+        type: 'X',
+        extras: {
+          test: 'test',
+        },
+        contractAddress: '0x00',
+      };
+      (prisma.project.create as jest.Mock).mockResolvedValue(mockRequest);
+      const result = await service.create(mockRequest);
+      expect(result).toBeDefined();
+      expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        ProjectEvents.PROJECT_CREATED,
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('list', () => {
+    it('should return list of projects', async () => {
+      (prisma.project.findMany as jest.Mock).mockResolvedValue(mockResponse);
+      const result = await service.list();
+      expect(result).toEqual(mockResponse);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThanOrEqual(1);
     });
 
-    describe('list', () => {
-        it('should return list of projects', async () => {
-            (prisma.project.findMany as jest.Mock).mockResolvedValue(mockResponse);
-            const result = await service.list();
-            expect(result).toEqual(mockResponse);
-            expect(Array.isArray(result)).toBe(true);
-            expect(result.length).toBeGreaterThanOrEqual(1); 
-        });
+    it('should return an empty list when no projects are found', async () => {
+      (prisma.project.findMany as jest.Mock).mockResolvedValue(null);
+      const result = await service.list();
+      console.log(result, 'result in list');
+      expect(result).toBeNull;
+    });
+  });
 
-        it('should return an empty list when no projects are found', async () => {
-            (prisma.project.findMany as jest.Mock).mockResolvedValue(null);
-            const result = await service.list();
-            console.log(result, 'result in list');
-            expect(result).toBeNull;
-        });
+  describe('findOne', () => {
+    it('should return specific project detail using uuid', async () => {
+      (prisma.project.findUnique as jest.Mock).mockResolvedValue(
+        mockResponse[0]
+      );
+      const result = await service.findOne(mockResponse[0].uuid);
+      expect(prisma.project.findUnique).toHaveBeenCalledWith({
+        where: {
+          uuid: mockResponse[0].uuid,
+        },
+      });
+      expect(result).toEqual(mockResponse[0]);
+      expect(result).not.toBeNull();
+      expect(result).not.toBeUndefined();
+      expect(result).toHaveProperty('uuid');
+    });
+  });
+
+  describe('update', () => {
+    it('should update the details of the project using uuid', async () => {
+      const mockRequest = {
+        name: 'updated name',
+        contractAddress: '0x11',
+      };
+      const mockResponseUpdate = {
+        id: 2,
+        uuid: randomUUID(),
+        name: 'updated name',
+        description: 'This is the description for Test Project 2.',
+        status: 'NOT_READY',
+        type: 'X',
+        contractAddress: '0x11',
+        extras: {
+          test: 'test',
+        },
+        createdAt: '2024-09-02T11:59:25.229Z',
+        updatedAt: '2024-09-02T11:59:25.229Z',
+        deletedAt: null,
+      };
+      (prisma.project.update as jest.Mock).mockResolvedValue(
+        mockResponseUpdate
+      );
+      const result = await service.update(mockResponseUpdate.uuid, mockRequest);
+      expect(prisma.project.update).toHaveBeenCalledWith({
+        where: {
+          uuid: mockResponseUpdate.uuid,
+        },
+        data: mockRequest,
+      });
+      expect(result).toEqual(mockResponseUpdate);
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('should update the status of the specific project using uuid', async () => {
+      const mockRequest = {
+        status: ProjectStatus.ACTIVE,
+        description: 'This is the description for Test Project 2.',
+      };
+      const mockResponseUpdate = {
+        id: 2,
+        uuid: randomUUID(),
+        name: 'updated name',
+        description: 'This is the description for Test Project 2.',
+        status: 'ACTIVE',
+        type: 'X',
+        contractAddress: '0x11',
+        extras: {
+          test: 'test',
+        },
+        createdAt: '2024-09-02T11:59:25.229Z',
+        updatedAt: '2024-09-02T11:59:25.229Z',
+        deletedAt: null,
+      };
+      (prisma.project.update as jest.Mock).mockResolvedValue(
+        mockResponseUpdate
+      );
+      const result = await service.update(mockResponseUpdate.uuid, mockRequest);
+      expect(prisma.project.update).toHaveBeenCalledWith({
+        where: {
+          uuid: mockResponseUpdate.uuid,
+        },
+        data: mockRequest,
+      });
+      expect(result).toEqual(mockResponseUpdate);
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe('getKoboCountryCodeFromSettings', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
     });
 
-    describe('findOne', () => {
-        it('should return specific project detail using uuid', async () => {
-            (prisma.project.findUnique as jest.Mock).mockResolvedValue(mockResponse[0]);
-            const result = await service.findOne(mockResponse[0].uuid);
-            expect(prisma.project.findUnique).toHaveBeenCalledWith({
-                where: {
-                    uuid: mockResponse[0].uuid
-                }
-            });
-            expect(result).toEqual(mockResponse[0]);
-            expect(result).not.toBeNull();
-            expect(result).not.toBeUndefined();
-            expect(result).toHaveProperty('uuid');
-        });
+    it("should return the calling code stored under the setting's country key", async () => {
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        name: 'COUNTRY_CODE_SETTINGS',
+        value: { CHINA: ' +86 ' },
+      });
+      const result = await service.getKoboCountryCodeFromSettings();
+      expect(prisma.setting.findUnique).toHaveBeenCalledWith({
+        where: { name: 'COUNTRY_CODE_SETTINGS' },
+      });
+      expect(result).toBe('+86');
     });
 
-    describe('update', () => {
-        it('should update the details of the project using uuid', async () => {
-            const mockRequest = {
-                name: "updated name",
-                contractAddress: "0x11"
-            };
-            const mockResponseUpdate = {
-                id: 2,
-                uuid: randomUUID(),
-                name: "updated name",
-                description: "This is the description for Test Project 2.",
-                status: "NOT_READY",
-                type: "X",
-                contractAddress: "0x11",
-                extras: {
-                  test: "test"
-                },
-                createdAt: "2024-09-02T11:59:25.229Z",
-                updatedAt: "2024-09-02T11:59:25.229Z",
-                deletedAt: null
-            };
-            (prisma.project.update as jest.Mock).mockResolvedValue(mockResponseUpdate);
-            const result = await service.update(mockResponseUpdate.uuid, mockRequest);
-            expect(prisma.project.update).toHaveBeenCalledWith({
-                where: {
-                    uuid: mockResponseUpdate.uuid
-                },
-                data: mockRequest
-            });
-            expect(result).toEqual(mockResponseUpdate);
-            expect(result).not.toBeNull();
-        });
+    it('should return an empty string when the setting does not exist', async () => {
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue(null);
+      const result = await service.getKoboCountryCodeFromSettings();
+      expect(result).toBe('');
     });
 
-    describe('updateStatus', () => {
-        it('should update the status of the specific project using uuid', async () => {
-            const mockRequest = {
-                status: ProjectStatus.ACTIVE,
-                description: "This is the description for Test Project 2.",
-            };
-            const mockResponseUpdate = {
-                id: 2,
-                uuid: randomUUID(),
-                name: "updated name",
-                description: "This is the description for Test Project 2.",
-                status: "ACTIVE",
-                type: "X",
-                contractAddress: "0x11",
-                extras: {
-                  test: "test"
-                },
-                createdAt: "2024-09-02T11:59:25.229Z",
-                updatedAt: "2024-09-02T11:59:25.229Z",
-                deletedAt: null
-            };
-            (prisma.project.update as jest.Mock).mockResolvedValue(mockResponseUpdate);
-            const result = await service.update(mockResponseUpdate.uuid, mockRequest);
-            expect(prisma.project.update).toHaveBeenCalledWith({
-                where: {
-                    uuid: mockResponseUpdate.uuid
-                },
-                data: mockRequest
-            });
-            expect(result).toEqual(mockResponseUpdate);
-            expect(result).not.toBeNull();
-        });
+    it('should return the code when the setting is stored as a bare string', async () => {
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        name: 'COUNTRY_CODE_SETTINGS',
+        value: '86',
+      });
+      const result = await service.getKoboCountryCodeFromSettings();
+      expect(result).toBe('86');
     });
+
+    it('should skip values that do not look like a calling code', async () => {
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        name: 'COUNTRY_CODE_SETTINGS',
+        value: { NOTE: 'set by admin', CHINA: '+86' },
+      });
+      const result = await service.getKoboCountryCodeFromSettings();
+      expect(result).toBe('+86');
+    });
+
+    it('should skip a value too long to be a calling code', async () => {
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        name: 'COUNTRY_CODE_SETTINGS',
+        value: { PHONE: '9779843777474', CHINA: '+86' },
+      });
+      const result = await service.getKoboCountryCodeFromSettings();
+      expect(result).toBe('+86');
+    });
+
+    it('should return an empty string when the code is nested a level deeper', async () => {
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        name: 'COUNTRY_CODE_SETTINGS',
+        value: { DEFAULT: { CHINA: '+86' } },
+      });
+      const result = await service.getKoboCountryCodeFromSettings();
+      expect(result).toBe('');
+    });
+
+    it('should return an empty string when the value has no string field', async () => {
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        name: 'COUNTRY_CODE_SETTINGS',
+        value: { PRIORITY: 1 },
+      });
+      const result = await service.getKoboCountryCodeFromSettings();
+      expect(result).toBe('');
+    });
+
+    it('should return an empty string when the lookup throws', async () => {
+      (prisma.setting.findUnique as jest.Mock).mockRejectedValue(
+        new Error('db down')
+      );
+      const result = await service.getKoboCountryCodeFromSettings();
+      expect(result).toBe('');
+    });
+  });
+
+  describe('getKoboCountryCodeFromSettings caching', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+      jest.clearAllMocks();
+    });
+
+    it('should reuse the cached value on a second call within the TTL', async () => {
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '86' },
+      });
+      const first = await service.getKoboCountryCodeFromSettings();
+      const second = await service.getKoboCountryCodeFromSettings();
+      expect(first).toBe('86');
+      expect(second).toBe('86');
+      expect(prisma.setting.findUnique).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep serving the cache right up to the expiry instant', async () => {
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '86' },
+      });
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      await service.getKoboCountryCodeFromSettings();
+      nowSpy.mockReturnValue(
+        1_000_000 + envConfig.COUNTRY_CODE_CACHE_TTL_MS - 1
+      );
+      await service.getKoboCountryCodeFromSettings();
+      expect(prisma.setting.findUnique).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refetch once the cached value has expired', async () => {
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '86' },
+      });
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      await service.getKoboCountryCodeFromSettings();
+      nowSpy.mockReturnValue(
+        1_000_000 + envConfig.COUNTRY_CODE_CACHE_TTL_MS + 1
+      );
+      await service.getKoboCountryCodeFromSettings();
+      expect(prisma.setting.findUnique).toHaveBeenCalledTimes(2);
+    });
+
+    it('should pick up a code that was configured after the cache expired', async () => {
+      (prisma.setting.findUnique as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ value: { CHINA: '86' } });
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      expect(await service.getKoboCountryCodeFromSettings()).toBe('');
+      nowSpy.mockReturnValue(
+        1_000_000 + envConfig.COUNTRY_CODE_CACHE_TTL_MS + 1
+      );
+      expect(await service.getKoboCountryCodeFromSettings()).toBe('86');
+    });
+
+    it('should cache an unset setting too, rather than querying on every import', async () => {
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue(null);
+      await service.getKoboCountryCodeFromSettings();
+      await service.getKoboCountryCodeFromSettings();
+      expect(prisma.setting.findUnique).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not cache a failed lookup, so the next call retries', async () => {
+      (prisma.setting.findUnique as jest.Mock)
+        .mockRejectedValueOnce(new Error('db down'))
+        .mockResolvedValueOnce({ value: { CHINA: '86' } });
+      const first = await service.getKoboCountryCodeFromSettings();
+      const second = await service.getKoboCountryCodeFromSettings();
+      expect(first).toBe('');
+      expect(second).toBe('86');
+      expect(prisma.setting.findUnique).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('normalizeKoboPhone', () => {
+    let originalAutoApply: boolean;
+
+    beforeEach(() => {
+      originalAutoApply = envConfig.AUTO_APPLY_KOBO_COUNTRY_CODE;
+    });
+
+    afterEach(() => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = originalAutoApply;
+      jest.clearAllMocks();
+    });
+
+    it('should throw when phone is empty', async () => {
+      await expect(service.normalizeKoboPhone('')).rejects.toThrow(
+        'Phone number is required!'
+      );
+    });
+
+    it('should only strip non-digits and prefix "+" when auto-apply is disabled', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = false;
+      const result = await service.normalizeKoboPhone('0138 0000 1111');
+      expect(result).toBe('+013800001111');
+      expect(prisma.setting.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should leave a "+" prefixed phone untouched without reading the setting', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '86' },
+      });
+      const result = await service.normalizeKoboPhone('+8615012345678');
+      expect(result).toBe('+8615012345678');
+      expect(prisma.setting.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should prefix a local number written without a trunk zero', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '86' },
+      });
+      const result = await service.normalizeKoboPhone('13800001111');
+      expect(result).toBe('+8613800001111');
+    });
+
+    it('should strip a leading trunk zero and prefix the configured calling code', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '86' },
+      });
+      const result = await service.normalizeKoboPhone('013800001111');
+      expect(result).toBe('+8613800001111');
+    });
+
+    it('should not stack the configured code on a number that already starts with it', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '+86' },
+      });
+      const result = await service.normalizeKoboPhone('8615012345678');
+      expect(result).toBe('+8615012345678');
+    });
+
+    it('should keep an international "00" prefixed number and drop the "00"', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '+86' },
+      });
+      const result = await service.normalizeKoboPhone('00977 9843777474');
+      expect(result).toBe('+9779843777474');
+      expect(prisma.setting.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should still apply the configured code to a local number', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '+86' },
+      });
+      const result = await service.normalizeKoboPhone('15012345678');
+      expect(result).toBe('+8615012345678');
+    });
+
+    it('should strip formatting from a local number before prefixing', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '86' },
+      });
+      const result = await service.normalizeKoboPhone(' (0138) 0000-1111 ');
+      expect(result).toBe('+8613800001111');
+    });
+
+    it('should keep a "+" number as-is even when it is another country', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '+86' },
+      });
+      const result = await service.normalizeKoboPhone('+9779843777474');
+      expect(result).toBe('+9779843777474');
+      expect(prisma.setting.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should read the setting once across repeated imports', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue({
+        value: { CHINA: '86' },
+      });
+      await service.normalizeKoboPhone('013800001111');
+      await service.normalizeKoboPhone('013800001112');
+      expect(prisma.setting.findUnique).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw when auto-apply is on but no country code is configured', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue(null);
+      await expect(service.normalizeKoboPhone('013800001111')).rejects.toThrow(
+        'COUNTRY_CODE_SETTINGS'
+      );
+    });
+
+    it('should throw when the setting lookup fails', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      (prisma.setting.findUnique as jest.Mock).mockRejectedValue(
+        new Error('db down')
+      );
+      await expect(service.normalizeKoboPhone('013800001111')).rejects.toThrow(
+        'COUNTRY_CODE_SETTINGS'
+      );
+    });
+
+    it('should not throw when auto-apply is off and no code is configured', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = false;
+      (prisma.setting.findUnique as jest.Mock).mockResolvedValue(null);
+      const result = await service.normalizeKoboPhone('013800001111');
+      expect(result).toBe('+013800001111');
+    });
+
+    it('should throw when the phone is only formatting characters', async () => {
+      (envConfig as any).AUTO_APPLY_KOBO_COUNTRY_CODE = true;
+      await expect(service.normalizeKoboPhone('   ')).rejects.toThrow(
+        'Phone number is required!'
+      );
+    });
+  });
 });

--- a/apps/rahat/src/projects/project.service.ts
+++ b/apps/rahat/src/projects/project.service.ts
@@ -14,7 +14,6 @@ import {
   BeneficiaryJobs,
   BQUEUE,
   genRandomPhone,
-  generateRandomWallet,
   MS_ACTIONS,
   MS_TIMEOUT,
   ProjectEvents,
@@ -727,6 +726,8 @@ export class ProjectService {
     }
   }
 
+  // Normalises a Kobo phone to "+<digits>": an international number is kept as
+  // written, a local one gets the configured calling code minus its trunk zero.
   async normalizeKoboPhone(phone: string) {
     const rawPhone = String(phone || '').trim();
     if (!rawPhone) throw new Error('Phone number is required!');
@@ -737,10 +738,9 @@ export class ProjectService {
       return `+${digits.replace(/^00/, '')}`;
     const countryCode = await this.getKoboCountryCodeFromSettings();
     if (!countryCode) {
-      this.logger.error(
-        `[kobo-import] No country code configured in "${COUNTRY_CODE_SETTING_NAME}" setting; returning phone without a calling code.`
+      throw new Error(
+        `[kobo-import] AUTO_APPLY_KOBO_COUNTRY_CODE is enabled but "${COUNTRY_CODE_SETTING_NAME}" could not be resolved; refusing to import a phone without a calling code.`
       );
-      return `+${digits}`;
     }
     const callingCode = String(countryCode).replace(/\D/g, '');
 

--- a/apps/rahat/src/projects/project.service.ts
+++ b/apps/rahat/src/projects/project.service.ts
@@ -55,15 +55,20 @@ import { notificationActions } from './actions/common.action';
 import { commsActions } from './actions/comms.action';
 import { rpActions } from './actions/rp.action';
 import { userRequiredActions } from './actions/user-required.action';
-
-const NODE_ENV = process.env.NODE_ENV || 'development';
-const CAMBODIA_COUNTRY_CODE = '+855';
-const KOBO_COUNTRY_CODE =
-  process.env.KOBO_COUNTRY_CODE || process.env.DEFAULT_KOBO_COUNTRY_CODE;
+import {
+  AUTO_APPLY_KOBO_COUNTRY_CODE,
+  COUNTRY_CODE_CACHE_TTL_MS,
+  COUNTRY_CODE_SETTING_NAME,
+} from '../utils/envConfig';
+import {
+  hasCallingCode,
+  hasInternationalPrefix,
+} from '../utils/validateCountryCode';
 
 @Injectable()
 export class ProjectService {
   private readonly logger = new Logger(ProjectService.name);
+  private countryCodeCache: { value: string; expiresAt: number } | null = null;
 
   constructor(
     private prisma: PrismaService,
@@ -446,10 +451,7 @@ export class ProjectService {
         .split(' ')
         .map((item: string) => item.trim().toUpperCase());
     }
-    const countryCode =
-      KOBO_COUNTRY_CODE ||
-      (NODE_ENV === 'production' ? CAMBODIA_COUNTRY_CODE : '');
-    benef.phone = this.normalizeKoboPhone(benef.phone, countryCode);
+    benef.phone = await this.normalizeKoboPhone(benef.phone);
 
     const { piiData, type, ...rest } = createExtrasAndPIIData(benef);
     const extrasPayload = {
@@ -691,25 +693,60 @@ export class ProjectService {
       );
   }
 
-  normalizeKoboPhone(phone: string, countryCode = '') {
+  // Reads the calling code from COUNTRY_CODE_SETTINGS ({ CHINA: '+86' } ->
+  // '+86'), cached for the TTL. Returns '' when unset or unreadable.
+  async getKoboCountryCodeFromSettings(): Promise<string> {
+    if (this.countryCodeCache && this.countryCodeCache.expiresAt > Date.now()) {
+      return this.countryCodeCache.value;
+    }
+    try {
+      const setting = await this.prisma.setting.findUnique({
+        where: { name: COUNTRY_CODE_SETTING_NAME },
+      });
+      const value = setting?.value as unknown;
+      const candidates =
+        value && typeof value === 'object' ? Object.values(value) : [value];
+      const code = candidates.find((v) => {
+        if (typeof v !== 'string') return false;
+        const codeDigits = v.replace(/\D/g, '');
+        return codeDigits.length > 0 && codeDigits.length <= 4;
+      });
+      const result = typeof code === 'string' ? code.trim() : '';
+      this.countryCodeCache = {
+        value: result,
+        expiresAt: Date.now() + COUNTRY_CODE_CACHE_TTL_MS,
+      };
+      return result;
+    } catch (err) {
+      this.logger.error(
+        `[kobo-import] Failed to read ${COUNTRY_CODE_SETTING_NAME}: ${
+          (err as Error)?.message
+        }`
+      );
+      return '';
+    }
+  }
+
+  async normalizeKoboPhone(phone: string) {
     const rawPhone = String(phone || '').trim();
     if (!rawPhone) throw new Error('Phone number is required!');
-
-    const normalizedCountryCode = countryCode
-      ? `+${String(countryCode).replace(/\D/g, '')}`
-      : '';
     const digits = rawPhone.replace(/\D/g, '');
+    if (!AUTO_APPLY_KOBO_COUNTRY_CODE) return `+${digits}`;
 
-    if (rawPhone.startsWith('+')) return `+${digits}`;
-
-    if (normalizedCountryCode) {
-      const countryDigits = normalizedCountryCode.replace(/\D/g, '');
-      if (digits.startsWith(countryDigits)) return `+${digits}`;
-
-      return `${normalizedCountryCode}${digits.replace(/^0+/, '')}`;
+    if (hasInternationalPrefix(rawPhone))
+      return `+${digits.replace(/^00/, '')}`;
+    const countryCode = await this.getKoboCountryCodeFromSettings();
+    if (!countryCode) {
+      this.logger.error(
+        `[kobo-import] No country code configured in "${COUNTRY_CODE_SETTING_NAME}" setting; returning phone without a calling code.`
+      );
+      return `+${digits}`;
     }
+    const callingCode = String(countryCode).replace(/\D/g, '');
 
-    return `+${digits}`;
+    if (hasCallingCode(digits, callingCode)) return `+${digits}`;
+
+    return `+${callingCode}${digits.replace(/^0+/, '')}`;
   }
 
   async sendTestMsg(uuid: UUID) {

--- a/apps/rahat/src/utils/envConfig.ts
+++ b/apps/rahat/src/utils/envConfig.ts
@@ -1,0 +1,5 @@
+export const COUNTRY_CODE_SETTING_NAME = 'COUNTRY_CODE_SETTINGS';
+export const AUTO_APPLY_KOBO_COUNTRY_CODE =
+  process.env.AUTO_APPLY_KOBO_COUNTRY_CODE === 'true';
+export const COUNTRY_CODE_CACHE_TTL_MS =
+  Number(process.env.COUNTRY_CODE_CACHE_TTL_MS) || 60_000;

--- a/apps/rahat/src/utils/envConfig.ts
+++ b/apps/rahat/src/utils/envConfig.ts
@@ -1,4 +1,9 @@
 export const COUNTRY_CODE_SETTING_NAME = 'COUNTRY_CODE_SETTINGS';
+
+// Read once at process start, so flipping this env var needs a restart —
+// unlike COUNTRY_CODE_SETTINGS, which is cached with a TTL and can be updated
+// live through the settings table. It must be a real process env var: this is
+// evaluated before ConfigModule loads the .env file.
 export const AUTO_APPLY_KOBO_COUNTRY_CODE =
   process.env.AUTO_APPLY_KOBO_COUNTRY_CODE === 'true';
 export const COUNTRY_CODE_CACHE_TTL_MS =

--- a/apps/rahat/src/utils/validateCountryCode.spec.ts
+++ b/apps/rahat/src/utils/validateCountryCode.spec.ts
@@ -1,0 +1,91 @@
+import { hasCallingCode, hasInternationalPrefix } from './validateCountryCode';
+
+describe('hasInternationalPrefix', () => {
+  it('should detect a leading +', () => {
+    expect(hasInternationalPrefix('+8613800001111')).toBe(true);
+  });
+
+  it('should detect a leading 00', () => {
+    expect(hasInternationalPrefix('008613800001111')).toBe(true);
+  });
+
+  it('should detect a + that is not the first character', () => {
+    expect(hasInternationalPrefix('(+86) 138 0000 1111')).toBe(true);
+  });
+
+  it('should return false for a local number', () => {
+    expect(hasInternationalPrefix('013800001111')).toBe(false);
+  });
+
+  it('should return false for a leading single zero', () => {
+    expect(hasInternationalPrefix('013800001111')).toBe(false);
+  });
+
+  it('should ignore surrounding whitespace', () => {
+    expect(hasInternationalPrefix('  +8613800001111  ')).toBe(true);
+  });
+
+  it('should return false for an empty phone', () => {
+    expect(hasInternationalPrefix('')).toBe(false);
+  });
+
+  it('should return false for a null or undefined phone', () => {
+    expect(hasInternationalPrefix(null as unknown as string)).toBe(false);
+    expect(hasInternationalPrefix(undefined as unknown as string)).toBe(false);
+  });
+});
+
+describe('hasCallingCode', () => {
+  it('should match a number that already has the calling code', () => {
+    expect(hasCallingCode('8613800001111', '86')).toBe(true);
+  });
+
+  it('should accept the calling code written with a "+"', () => {
+    expect(hasCallingCode('8613800001111', '+86')).toBe(true);
+  });
+
+  it('should not match a local-only number', () => {
+    expect(hasCallingCode('13800001111', '86')).toBe(false);
+  });
+
+  it('should not match another country calling code', () => {
+    expect(hasCallingCode('9779843777474', '86')).toBe(false);
+  });
+
+  it('should not treat a local number as prefixed just because it starts with a short code', () => {
+    // libphonenumber will happily report calling code 20/7 for these, but they
+    // are not valid numbers — without the validity check they would be left
+    // unprefixed. Only relevant if COUNTRY_CODE_SETTINGS moves to a 1-2 digit
+    // code; "86" is unaffected either way.
+    expect(hasCallingCode('201234567', '20')).toBe(false);
+    expect(hasCallingCode('7123456789', '7')).toBe(false);
+  });
+
+  it('should still match real numbers that carry a short calling code', () => {
+    expect(hasCallingCode('201001234567', '20')).toBe(true);
+    expect(hasCallingCode('79161234567', '7')).toBe(true);
+  });
+
+  it('should not add the code twice when the digits cannot be parsed', () => {
+    expect(hasCallingCode('86', '86')).toBe(true);
+  });
+
+  it('should ignore formatting characters in the phone', () => {
+    expect(hasCallingCode('+86 138 0000 1111', '86')).toBe(true);
+  });
+
+  it('should return false when either argument is empty', () => {
+    expect(hasCallingCode('', '86')).toBe(false);
+    expect(hasCallingCode('8613800001111', '')).toBe(false);
+  });
+
+  it('should return false when either argument has no digits', () => {
+    expect(hasCallingCode('not-a-phone', '86')).toBe(false);
+    expect(hasCallingCode('8613800001111', '+')).toBe(false);
+  });
+
+  it('should return false for a null or undefined phone', () => {
+    expect(hasCallingCode(null as unknown as string, '86')).toBe(false);
+    expect(hasCallingCode(undefined as unknown as string, '86')).toBe(false);
+  });
+});

--- a/apps/rahat/src/utils/validateCountryCode.ts
+++ b/apps/rahat/src/utils/validateCountryCode.ts
@@ -1,0 +1,21 @@
+import { parsePhoneNumberFromString } from 'libphonenumber-js';
+
+// true when the number already carries the configured country code (e.g. an
+// "86" number while COUNTRY_CODE_SETTINGS is "+86"), so no need to ad.
+export function hasCallingCode(phone: string, callingCode: string): boolean {
+  const digits = String(phone || '').replace(/\D/g, '');
+  const code = String(callingCode || '').replace(/\D/g, '');
+  if (!digits || !code) return false;
+
+  const parsed = parsePhoneNumberFromString(`+${digits}`);
+  return parsed ? parsed.countryCallingCode === code : digits.startsWith(code);
+}
+
+// true when the number was written in international form ("+86" or "0086"),
+// i.e. the user already stated the country and no need to add.
+export function hasInternationalPrefix(phone: string): boolean {
+  const cleaned = String(phone || '')
+    .trim()
+    .replace(/[^\d+]/g, '');
+  return cleaned.startsWith('+') || cleaned.startsWith('00');
+}

--- a/apps/rahat/src/utils/validateCountryCode.ts
+++ b/apps/rahat/src/utils/validateCountryCode.ts
@@ -1,18 +1,20 @@
 import { parsePhoneNumberFromString } from 'libphonenumber-js';
 
-// true when the number already carries the configured country code (e.g. an
-// "86" number while COUNTRY_CODE_SETTINGS is "+86"), so no need to ad.
+// true when the number already carries the configured calling code.
 export function hasCallingCode(phone: string, callingCode: string): boolean {
   const digits = String(phone || '').replace(/\D/g, '');
   const code = String(callingCode || '').replace(/\D/g, '');
   if (!digits || !code) return false;
 
   const parsed = parsePhoneNumberFromString(`+${digits}`);
-  return parsed ? parsed.countryCallingCode === code : digits.startsWith(code);
+  // validity rules out a local number that merely starts with a short code
+  if (parsed) return parsed.countryCallingCode === code && parsed.isValid();
+
+  // unparseable digits ("86"): prefix match still avoids adding the code twice
+  return digits.startsWith(code);
 }
 
-// true when the number was written in international form ("+86" or "0086"),
-// i.e. the user already stated the country and no need to add.
+// true when the number was written in international from ("+86" or "0086").
 export function hasInternationalPrefix(phone: string): boolean {
   const cleaned = String(phone || '')
     .trim()

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "http-status-codes": "^2.3.0",
     "inquirer": "^12.0.0",
     "ioredis": "^5.3.2",
+    "libphonenumber-js": "^1.13.10",
     "nepali-number": "^1.0.3",
     "nest-winston": "^1.9.4",
     "nodemailer": "^6.9.11",


### PR DESCRIPTION
## Kobo collectors in the field only enter the local phone number, without a country code. This adds the country code on import so numbers are stored in E.164 form.

## How

On every Kobo import, the phone is checked:

- already written as `+86…` or `0086…` → left as is
- already carries the configured code (`86…`) → left as is
- anything else → treated as local, configured code added, trunk zero dropped

The code comes from the `COUNTRY_CODE_SETTINGS` setting in the database.
`libphonenumber-js` is used to detect whether the code is already there.

## Deployment

Needs `AUTO_APPLY_KOBO_COUNTRY_CODE=true` in production, plus a
`COUNTRY_CODE_SETTINGS` row (e.g. `{ "CHINA": "+86" }`) in production database.

Replaces the old `KOBO_COUNTRY_CODE` env var and the hardcoded `+855` fallback used for CAMBODIA.